### PR TITLE
Canonical pages and nofollow for non ARRRmada Sites

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ description: >-
   The ARRRmada is a link directory for all stores, service providers and companies 
   that accept ARRR as a payment.
 baseurl: "/" 
-url: "https://arrrmada.com" #https://arrrmada.com 
+url: "https://quirkyrobots.github.io/arrrmada"
 repo: https://github.com/ARRRmada/ARRRmada.com
 readme: https://github.com/ARRRmada/ARRRmada.com
 

--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,7 @@
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
 
+permalink: /:path/:basename
 title: ARRRmada Directory - ARRR (Pirate Chain) accepted here
 keywords: cryptocurrency, privacy, pirate chain, arrr, fungible
 email: ARRRmada@pirate.black

--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ description: >-
   The ARRRmada is a link directory for all stores, service providers and companies 
   that accept ARRR as a payment.
 baseurl: "/" 
-url: "https://quirkyrobots.github.io/arrrmada"
+url: "https://arrrmada.com" #https://arrrmada.com 
 repo: https://github.com/ARRRmada/ARRRmada.com
 readme: https://github.com/ARRRmada/ARRRmada.com
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,7 +7,12 @@
     <meta name="author" content="Pirate Chain" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#151326" />
+    <!--Help protect pages being classed as duplicate content-->
+    {% if site.url == "https://arrrmada.com" %}
     <meta name="robots" content="index, follow" />
+    {% else %}
+    <meta name="robots" content="index, nofollow" />
+    {% endif %}
 
     <!--Open Graph Tags-->
     <meta property="og:locale" content="en_US" />
@@ -29,7 +34,7 @@
     <meta name="twitter:image" content="{{ site.baseurl }}/assets/img/site/arrrmada.jpg" />
 
     <!--Link Tags-->
-    <link rel="canonical" href="https://arrrmada.com/" />
+    <link rel="canonical" href="https://arrrmada.com{{ page.permalink | default: page.url }}" />
     <link rel="icon" href="{{ site.baseurl }}/assets/img/site/Pirate_Logo_Ship_Gold.svg" sizes="any" type="image/svg+xml" />
     <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/css/global.css" />
     {% include links.html %}


### PR DESCRIPTION
Adds a canonical setting that makes each page its own canonical page rather than using the root URL.
Changes follow to nofollow if the site URL isn't https://arrrmada.com